### PR TITLE
Add MicroBadger badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # PHP testing base
 
 ![](https://img.shields.io/docker/stars/mileschou/php-testing-base.svg)
-![](https://img.shields.io/docker/pulls/mileschou/php-testing-base.svg)
+![](https://img.shields.io/docker/pulls/mileschou/php-testing-base.svg) [![](https://images.microbadger.com/badges/image/mileschou/php-testing-base.svg)](https://microbadger.com/images/mileschou/php-testing-base "Get your own image badge on microbadger.com")
 
 PHP testing base include Composer for GitLab CI or other CI system.
+ 


### PR DESCRIPTION
We saw your image on Docker Hub at [mileschou/php-testing-base](https://hub.docker.com/r/mileschou/php-testing-base/), and we thought you might like this badge for your GitHub readme showing the image contents.

The badge shows the number of layers and download size of your Docker image, and links to our site where you can see the [contents of each layer](https://microbadger.com/images/mileschou/php-testing-base).

As you're using an automated build it will also show up in your Docker Hub description.

[![](https://images.microbadger.com/badges/image/mileschou/php-testing-base.svg)](https://microbadger.com/images/mileschou/php-testing-base)
