### PR TITLE
Add git to all images for better usability in GitLab CI.

### DIFF
--- a/5.5/Dockerfile
+++ b/5.5/Dockerfile
@@ -16,6 +16,7 @@ RUN set -xe && \
             autoconf \
             g++ \
             make \
+            git \
         && \
         pecl install xdebug-2.5.5 && \
         docker-php-ext-enable xdebug && \

--- a/5.6/Dockerfile
+++ b/5.6/Dockerfile
@@ -16,6 +16,7 @@ RUN set -xe && \
             autoconf \
             g++ \
             make \
+            git \
         && \
         pecl install xdebug-2.5.5 && \
         docker-php-ext-enable xdebug && \

--- a/7.0/Dockerfile
+++ b/7.0/Dockerfile
@@ -16,6 +16,7 @@ RUN set -xe && \
             autoconf \
             g++ \
             make \
+            git \
         && \
         pecl install xdebug-2.9.0 && \
         docker-php-ext-enable xdebug && \

--- a/7.1/Dockerfile
+++ b/7.1/Dockerfile
@@ -16,6 +16,7 @@ RUN set -xe && \
             autoconf \
             g++ \
             make \
+            git \
         && \
         pecl install xdebug && \
         docker-php-ext-enable xdebug && \

--- a/7.2/Dockerfile
+++ b/7.2/Dockerfile
@@ -16,6 +16,7 @@ RUN set -xe && \
             autoconf \
             g++ \
             make \
+            git \
         && \
         pecl install xdebug && \
         docker-php-ext-enable xdebug && \

--- a/7.3/Dockerfile
+++ b/7.3/Dockerfile
@@ -16,6 +16,7 @@ RUN set -xe && \
             autoconf \
             g++ \
             make \
+            git \
         && \
         pecl install xdebug && \
         docker-php-ext-enable xdebug && \

--- a/7.4/Dockerfile
+++ b/7.4/Dockerfile
@@ -16,6 +16,7 @@ RUN set -xe && \
             autoconf \
             g++ \
             make \
+            git \
         && \
         pecl install xdebug && \
         docker-php-ext-enable xdebug && \


### PR DESCRIPTION
I came across the problem that in order to use this in GitLab CI, I need `git` for use with some composer packages. I expect this is a use-case for a lot of people.